### PR TITLE
Support for multiple windows

### DIFF
--- a/Helium/Helium/AppDelegate.swift
+++ b/Helium/Helium/AppDelegate.swift
@@ -16,8 +16,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     
     @IBOutlet weak var magicURLMenu: NSMenuItem!
     
+    func application(application: NSApplication, didFinishLaunchingWithOptions launchOptions: NSDictionary?) -> Bool {
+        
+        return true
+    }
+    
     func applicationDidFinishLaunching(aNotification: NSNotification) {
-        self.popNewWindow(aNotification)
+        if(windowStack.isEmpty){
+            self.popNewWindow(aNotification)
+        }
         
         // Insert code here to initialize your application
         magicURLMenu.state = NSUserDefaults.standardUserDefaults().boolForKey("disabledMagicURLs") ? NSOffState : NSOnState
@@ -27,9 +34,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             forEventClass: AEEventClass(kInternetEventClass),
             andEventID: AEEventID(kAEGetURL)
         )
-        
     }
 
+    
+    
+    
     func applicationWillTerminate(aNotification: NSNotification) {
         // Insert code here to tear down your application
     }
@@ -44,9 +53,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     @IBAction func popNewWindow(sender: AnyObject){
         var nextWindowController : HeliumPanelController = NSStoryboard(name: "Main", bundle: nil)?.instantiateControllerWithIdentifier("HeliumController") as! HeliumPanelController
         
+        
         nextWindowController.showWindow(sender)
         
         windowStack.append(nextWindowController)
+        
+        NSApp.addWindowsItem(nextWindowController.panel, title: nextWindowController.panel.title!, filename: false)
     }
     
     
@@ -55,9 +67,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     func handleURLEvent(event: NSAppleEventDescriptor, withReply reply: NSAppleEventDescriptor) {
         if let urlString:String? = event.paramDescriptorForKeyword(AEKeyword(keyDirectObject))?.stringValue {
             if let url:String? = urlString?.substringFromIndex(advance(urlString!.startIndex,9)){
-                var urlObject:NSURL = NSURL(string:url!)!
-                //NOTE:
-                let hP : HeliumPanelController = windowStack[0]
+                var urlObject:NSURL = NSURL(string:("http://" + url!))!
+                
+                popNewWindow(self)
+                
+                let hP : HeliumPanelController = windowStack.last!
                 hP.webViewController.loadURL(urlObject)
             }else {
                 println("No valid URL to handle")
@@ -68,4 +82,3 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
 }
-

--- a/Helium/Helium/AppDelegate.swift
+++ b/Helium/Helium/AppDelegate.swift
@@ -15,11 +15,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     var windowStack : Array<HeliumPanelController> = []
     
     @IBOutlet weak var magicURLMenu: NSMenuItem!
-    
-    func application(application: NSApplication, didFinishLaunchingWithOptions launchOptions: NSDictionary?) -> Bool {
-        
-        return true
-    }
+    @IBOutlet var windowsMenu: NSMenu!
     
     func applicationDidFinishLaunching(aNotification: NSNotification) {
         if(windowStack.isEmpty){
@@ -53,12 +49,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     @IBAction func popNewWindow(sender: AnyObject){
         var nextWindowController : HeliumPanelController = NSStoryboard(name: "Main", bundle: nil)?.instantiateControllerWithIdentifier("HeliumController") as! HeliumPanelController
         
-        
         nextWindowController.showWindow(sender)
         
         windowStack.append(nextWindowController)
-        
-        NSApp.addWindowsItem(nextWindowController.panel, title: nextWindowController.panel.title!, filename: false)
     }
     
     

--- a/Helium/Helium/AppDelegate.swift
+++ b/Helium/Helium/AppDelegate.swift
@@ -11,9 +11,13 @@ import Cocoa
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
+    //Necessary to retain all of the information in each window
+    var windowStack : Array<HeliumPanelController> = []
+    
     @IBOutlet weak var magicURLMenu: NSMenuItem!
     
     func applicationDidFinishLaunching(aNotification: NSNotification) {
+        self.popNewWindow(aNotification)
         
         // Insert code here to initialize your application
         magicURLMenu.state = NSUserDefaults.standardUserDefaults().boolForKey("disabledMagicURLs") ? NSOffState : NSOnState
@@ -37,14 +41,24 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
     
     
+    @IBAction func popNewWindow(sender: AnyObject){
+        var nextWindowController : HeliumPanelController = NSStoryboard(name: "Main", bundle: nil)?.instantiateControllerWithIdentifier("HeliumController") as! HeliumPanelController
+        
+        nextWindowController.showWindow(sender)
+        
+        windowStack.append(nextWindowController)
+    }
+    
+    
 //MARK: - handleURLEvent
     // Called when the App opened via URL.
     func handleURLEvent(event: NSAppleEventDescriptor, withReply reply: NSAppleEventDescriptor) {
         if let urlString:String? = event.paramDescriptorForKeyword(AEKeyword(keyDirectObject))?.stringValue {
             if let url:String? = urlString?.substringFromIndex(advance(urlString!.startIndex,9)){
                 var urlObject:NSURL = NSURL(string:url!)!
-            NSNotificationCenter.defaultCenter().postNotificationName("HeliumLoadURL", object: urlObject)
-                
+                //NOTE:
+                let hP : HeliumPanelController = windowStack[0]
+                hP.webViewController.loadURL(urlObject)
             }else {
                 println("No valid URL to handle")
             }
@@ -52,5 +66,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             
         }
     }
+
 }
 

--- a/Helium/Helium/Base.lproj/Main.storyboard
+++ b/Helium/Helium/Base.lproj/Main.storyboard
@@ -126,63 +126,63 @@ CA
                                                 <action selector="translucencyPress:" target="Ady-hI-5gd" id="orR-QV-BPD"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Opacity" id="wlj-XI-Lng">
+                                        <menuItem title="Opacity" id="5bW-LE-EpB">
                                             <modifierMask key="keyEquivalentModifierMask"/>
-                                            <menu key="submenu" title="Opacity" systemMenu="window" id="5ao-Bb-P10">
+                                            <menu key="submenu" title="Opacity" id="e1b-bV-96e">
                                                 <items>
-                                                    <menuItem title="10%" keyEquivalent="1" id="SpQ-gr-DsG">
+                                                    <menuItem title="10%" keyEquivalent="1" id="veS-Jx-MHO">
                                                         <connections>
-                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="RXN-qL-deK"/>
+                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="Z4J-pz-GIq"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="20%" keyEquivalent="2" id="B4x-FQ-kVj">
+                                                    <menuItem title="20%" keyEquivalent="2" id="Cnk-eR-xqR">
                                                         <connections>
-                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="SJU-4R-onV"/>
+                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="Mt2-Ua-Eau"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="30%" keyEquivalent="3" id="S1G-zW-xWx">
+                                                    <menuItem title="30%" keyEquivalent="3" id="YHC-DY-ZAA">
                                                         <connections>
-                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="UJH-Ul-L4m"/>
+                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="7Kd-Yz-rgd"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="40%" keyEquivalent="4" id="sB8-xz-mYZ">
+                                                    <menuItem title="40%" keyEquivalent="4" id="RmG-CG-dsW">
                                                         <connections>
-                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="sew-bc-Bz1"/>
+                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="PvF-YM-yaE"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="50%" keyEquivalent="5" id="BNJ-gh-yGK">
+                                                    <menuItem title="50%" keyEquivalent="5" id="r3h-Ff-l9p">
                                                         <connections>
-                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="Aa8-hl-bKq"/>
+                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="k2x-rk-cYK"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="60%" state="on" keyEquivalent="6" id="iS5-Jd-p7Q">
+                                                    <menuItem title="60%" state="on" keyEquivalent="6" id="RHs-9y-DP1">
                                                         <connections>
-                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="du4-a9-MJw"/>
+                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="vdn-IP-TSP"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="70%" keyEquivalent="7" id="0pX-17-4u5">
+                                                    <menuItem title="70%" keyEquivalent="7" id="JV8-0M-3eG">
                                                         <connections>
-                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="AjV-cx-Ila"/>
+                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="GQ9-ph-tcZ"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="80%" keyEquivalent="8" id="mJa-We-e3P">
+                                                    <menuItem title="80%" keyEquivalent="8" id="Fh7-Ot-hI3">
                                                         <connections>
-                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="Ets-Bj-vej"/>
+                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="Cus-Lt-gFK"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="90%" keyEquivalent="9" id="JLI-El-Rtf">
+                                                    <menuItem title="90%" keyEquivalent="9" id="Wce-Sv-sqP">
                                                         <connections>
-                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="jqj-3n-Dci"/>
+                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="nQl-rW-ehS"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="100%" keyEquivalent="0" id="2NP-ZM-pKs">
+                                                    <menuItem title="100%" keyEquivalent="0" id="k3j-hH-Hms">
                                                         <connections>
-                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="wDd-yl-gr1"/>
+                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="R84-A1-4EJ"/>
                                                         </connections>
                                                     </menuItem>
                                                 </items>
                                                 <connections>
-                                                    <outlet property="delegate" destination="Voe-Tx-rLC" id="hNg-oj-Cad"/>
+                                                    <outlet property="delegate" destination="hnw-xV-0zn" id="Tb7-mh-FUF"/>
                                                 </connections>
                                             </menu>
                                         </menuItem>
@@ -307,7 +307,7 @@ CA
                 <customObject id="sQQ-SA-Rgm" customClass="SUUpdater"/>
                 <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="75" y="0.0"/>
+            <point key="canvasLocation" x="84.5" y="-79"/>
         </scene>
         <!--Window Controller-->
         <scene sceneID="R2V-B0-nI4">

--- a/Helium/Helium/Base.lproj/Main.storyboard
+++ b/Helium/Helium/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7702"/>
     </dependencies>
@@ -76,6 +76,11 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Location" id="bib-Uj-vzu">
                                     <items>
+                                        <menuItem title="New Window" keyEquivalent="n" id="t5r-Hg-m7h">
+                                            <connections>
+                                                <action selector="popNewWindow:" target="Voe-Tx-rLC" id="cxe-uj-4at"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Open Web URL..." keyEquivalent="l" id="JqH-ds-lJa">
                                             <connections>
                                                 <action selector="openLocationPress:" target="Ady-hI-5gd" id="28r-dM-HMi"/>
@@ -284,7 +289,7 @@ CA
             <objects>
                 <windowController storyboardIdentifier="HeliumController" showSeguePresentationStyle="single" id="B8D-0N-5wS" customClass="HeliumPanelController" customModule="Helium" customModuleProvider="target" sceneMemberID="viewController">
                     <window key="window" title="Helium" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA" customClass="NSPanel">
-                        <windowStyleMask key="styleMask" titled="YES" resizable="YES" utility="YES" HUD="YES"/>
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES" utility="YES" HUD="YES"/>
                         <windowCollectionBehavior key="collectionBehavior" moveToActiveSpace="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>
@@ -296,7 +301,7 @@ CA
                 </windowController>
                 <customObject id="Oky-zY-oP4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="75" y="250"/>
+            <point key="canvasLocation" x="273" y="251"/>
         </scene>
         <!--Web View Controller-->
         <scene sceneID="hIz-AP-VOD">

--- a/Helium/Helium/Base.lproj/Main.storyboard
+++ b/Helium/Helium/Base.lproj/Main.storyboard
@@ -256,6 +256,31 @@ CA
                                     </items>
                                 </menu>
                             </menuItem>
+                            <menuItem title="Window" id="kZI-41-SHO">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Window" systemMenu="window" id="mgQ-dO-9ix">
+                                    <items>
+                                        <menuItem title="Minimize" keyEquivalent="m" id="d73-Gc-eno">
+                                            <connections>
+                                                <action selector="performMiniaturize:" target="Ady-hI-5gd" id="cnY-BF-WZj"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Zoom" id="ZgR-as-G3V">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="performZoom:" target="Ady-hI-5gd" id="Xaz-Zr-z49"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="cbj-zK-tcH"/>
+                                        <menuItem title="Bring All to Front" id="GM6-Fd-KhN">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="arrangeInFront:" target="Ady-hI-5gd" id="h98-94-rya"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
                             <menuItem title="Help" id="wpr-3q-Mcd">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
@@ -288,7 +313,7 @@ CA
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController storyboardIdentifier="HeliumController" showSeguePresentationStyle="single" id="B8D-0N-5wS" customClass="HeliumPanelController" customModule="Helium" customModuleProvider="target" sceneMemberID="viewController">
-                    <window key="window" title="Helium" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA" customClass="NSPanel">
+                    <window key="window" title="Helium" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA" customClass="NSPanel">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES" utility="YES" HUD="YES"/>
                         <windowCollectionBehavior key="collectionBehavior" moveToActiveSpace="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
@@ -301,7 +326,7 @@ CA
                 </windowController>
                 <customObject id="Oky-zY-oP4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="273" y="251"/>
+            <point key="canvasLocation" x="162" y="243"/>
         </scene>
         <!--Web View Controller-->
         <scene sceneID="hIz-AP-VOD">

--- a/Helium/Helium/HeliumPanelController.swift
+++ b/Helium/Helium/HeliumPanelController.swift
@@ -10,8 +10,6 @@ import AppKit
 
 class HeliumPanelController : NSWindowController {
 
-    lazy var nextWindowController : HeliumPanelController = HeliumPanelController()
-    
     var alpha: CGFloat = 0.6 { //default
         didSet {
             if translucent {
@@ -51,6 +49,7 @@ class HeliumPanelController : NSWindowController {
     
     override func windowDidLoad() {
         panel.floatingPanel = true
+        
         
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "didBecomeActive", name: NSApplicationDidBecomeActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "willResignActive", name: NSApplicationWillResignActiveNotification, object: nil)
@@ -132,12 +131,6 @@ class HeliumPanelController : NSWindowController {
     }
     
     //MARK: Actual functionality
-    
-    func didUpdateTitle(notification: NSNotification) {
-        if let title = notification.object as? String {
-            panel.title = title
-        }
-    }
     
     func didRequestFile() {
         

--- a/Helium/Helium/HeliumPanelController.swift
+++ b/Helium/Helium/HeliumPanelController.swift
@@ -10,6 +10,8 @@ import AppKit
 
 class HeliumPanelController : NSWindowController {
 
+    lazy var nextWindowController : HeliumPanelController = HeliumPanelController()
+    
     var alpha: CGFloat = 0.6 { //default
         didSet {
             if translucent {
@@ -52,27 +54,20 @@ class HeliumPanelController : NSWindowController {
         
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "didBecomeActive", name: NSApplicationDidBecomeActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "willResignActive", name: NSApplicationWillResignActiveNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "didUpdateTitle:", name: "HeliumUpdateTitle", object: nil)
     }
     
     //MARK: IBActions
-    
+
     @IBAction func translucencyPress(sender: NSMenuItem) {
         if sender.state == NSOnState {
-            sender.state = NSOffState
             didDisableTranslucency()
         }
         else {
-            sender.state = NSOnState
             didEnableTranslucency()
         }
     }
     
     @IBAction func percentagePress(sender: NSMenuItem) {
-        for button in sender.menu!.itemArray{
-            (button as! NSMenuItem).state = NSOffState
-        }
-        sender.state = NSOnState
         let value = sender.title.substringToIndex(advance(sender.title.endIndex, -1))
         if let alpha = value.toInt() {
              didUpdateAlpha(NSNumber(integer: alpha))
@@ -123,6 +118,15 @@ class HeliumPanelController : NSWindowController {
         }
         if(menuItem.title == "Go Forward"){
             rValue = webViewController.webView.canGoForward
+        }
+        if(menuItem.title == "Translucent"){
+            menuItem.state = (translucent) ? NSOnState : NSOffState
+        }
+        if menuItem.menu?.title == "Opacity" {
+            rValue = translucent
+            let aValue = Int(self.alpha * 100)
+            let aString = "\(aValue)%"
+            menuItem.state = (menuItem.title == aString) ? NSOnState : NSOffState
         }
         return rValue
     }

--- a/Helium/Helium/HeliumPanelController.swift
+++ b/Helium/Helium/HeliumPanelController.swift
@@ -50,7 +50,6 @@ class HeliumPanelController : NSWindowController {
     override func windowDidLoad() {
         panel.floatingPanel = true
         
-        
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "didBecomeActive", name: NSApplicationDidBecomeActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "willResignActive", name: NSApplicationWillResignActiveNotification, object: nil)
     }

--- a/Helium/Helium/WebViewController.swift
+++ b/Helium/Helium/WebViewController.swift
@@ -119,8 +119,6 @@ class WebViewController: NSViewController, WKNavigationDelegate {
                 setWindowTitle(title as String)
             }
         }
-        
-        
     }
 }
 

--- a/Helium/Helium/WebViewController.swift
+++ b/Helium/Helium/WebViewController.swift
@@ -14,8 +14,6 @@ class WebViewController: NSViewController, WKNavigationDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "loadURLObject:", name: "HeliumLoadURL", object: nil)
-        
         // Layout webview
         view.addSubview(webView)
         webView.frame = view.bounds
@@ -61,13 +59,6 @@ class WebViewController: NSViewController, WKNavigationDelegate {
         webView.loadRequest(NSURLRequest(URL: url))
     }
     
-//MARK: - loadURLObject
-    func loadURLObject(urlObject : NSNotification) {
-        if let url = urlObject.object as? NSURL {
-            loadURL(url);
-        }
-    }
-    
     func requestedReload() {
         webView.reload()
     }
@@ -103,12 +94,15 @@ class WebViewController: NSViewController, WKNavigationDelegate {
         decisionHandler(WKNavigationActionPolicy.Allow)
     }
     
+    func setWindowTitle(newTitle : String){
+        self.view.window?.title = newTitle
+    }
+    
     func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation) {
         if let pageTitle = webView.title {
             var title = pageTitle;
             if title.isEmpty { title = "Helium" }
-            let notif = NSNotification(name: "HeliumUpdateTitle", object: title);
-            NSNotificationCenter.defaultCenter().postNotification(notif)
+            setWindowTitle(title)
         }
     }
     
@@ -121,9 +115,7 @@ class WebViewController: NSViewController, WKNavigationDelegate {
                 if percent == 100 {
                     title = "Helium"
                 }
-                
-                let notif = NSNotification(name: "HeliumUpdateTitle", object: title);
-                NSNotificationCenter.defaultCenter().postNotification(notif)
+                setWindowTitle(title as String)
             }
         }
         

--- a/Helium/Helium/WebViewController.swift
+++ b/Helium/Helium/WebViewController.swift
@@ -103,6 +103,7 @@ class WebViewController: NSViewController, WKNavigationDelegate {
             var title = pageTitle;
             if title.isEmpty { title = "Helium" }
             setWindowTitle(title)
+            NSApp.changeWindowsItem(self.view.window!, title: title, filename: false)
         }
     }
     


### PR DESCRIPTION
-New windows can be added by "CMD+N"
-Each window pops from the delegate, including the one that appears on
startup (note that this is a change from the initial storyboard setup)
-Replaced ALL NSNotification center calls made to directly modify each
window - This prevents signals from getting mixed up between two
different windows
-State for Transparency and Opacity menu items are inferred for each
window from the validateMenuItem method - No longer called manually
from each IBAction
-UNTESTED: Starting the app from URL - This method should work given
the changes I made, but I was unable to test it