### PR TITLE
add boss alert & remove translucent menuItem

### DIFF
--- a/Helium/Helium/Base.lproj/Main.storyboard
+++ b/Helium/Helium/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14D131" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7531"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7702"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -117,11 +117,6 @@ CA
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Appearance" id="HyV-fh-RgO">
                                     <items>
-                                        <menuItem title="Translucent" keyEquivalent="t" id="wnn-Wb-fUq">
-                                            <connections>
-                                                <action selector="translucencyPress:" target="Ady-hI-5gd" id="orR-QV-BPD"/>
-                                            </connections>
-                                        </menuItem>
                                         <menuItem title="Opacity" id="wlj-XI-Lng">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <menu key="submenu" title="Opacity" systemMenu="window" id="5ao-Bb-P10">

--- a/Helium/Helium/Base.lproj/Main.storyboard
+++ b/Helium/Helium/Base.lproj/Main.storyboard
@@ -121,9 +121,15 @@ CA
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <menu key="submenu" title="Opacity" systemMenu="window" id="5ao-Bb-P10">
                                                 <items>
-                                                    <menuItem title="10%" keyEquivalent="1" id="SpQ-gr-DsG">
+                                                    <menuItem title="Boss Alert" keyEquivalent="d" id="SpQ-gr-DsG">
+                                                        <attributedString key="attributedTitle"/>
                                                         <connections>
                                                             <action selector="percentagePress:" target="Ady-hI-5gd" id="RXN-qL-deK"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="10%" keyEquivalent="1" id="E6f-Cn-kpt">
+                                                        <connections>
+                                                            <action selector="percentagePress:" target="Ady-hI-5gd" id="tlx-uV-8wV"/>
                                                         </connections>
                                                     </menuItem>
                                                     <menuItem title="20%" keyEquivalent="2" id="B4x-FQ-kVj">
@@ -166,7 +172,7 @@ CA
                                                             <action selector="percentagePress:" target="Ady-hI-5gd" id="jqj-3n-Dci"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="100%" keyEquivalent="0" id="2NP-ZM-pKs">
+                                                    <menuItem title="100%" keyEquivalent="f" id="2NP-ZM-pKs">
                                                         <connections>
                                                             <action selector="percentagePress:" target="Ady-hI-5gd" id="wDd-yl-gr1"/>
                                                         </connections>
@@ -292,7 +298,7 @@ CA
                 </windowController>
                 <customObject id="Oky-zY-oP4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="75" y="250"/>
+            <point key="canvasLocation" x="587" y="156"/>
         </scene>
         <!--Web View Controller-->
         <scene sceneID="hIz-AP-VOD">

--- a/Helium/Helium/HeliumPanelController.swift
+++ b/Helium/Helium/HeliumPanelController.swift
@@ -17,7 +17,7 @@ class HeliumPanelController : NSWindowController {
             }
         }
     }
-    
+
     var translucent: Bool = false {
         didSet {
             if !NSApplication.sharedApplication().active {
@@ -33,41 +33,30 @@ class HeliumPanelController : NSWindowController {
             }
         }
     }
-    
-    
+
+
     var panel: NSPanel! {
         get {
             return (self.window as! NSPanel)
         }
     }
-    
+
     var webViewController: WebViewController {
         get {
             return self.window?.contentViewController as! WebViewController
         }
     }
-    
+
     override func windowDidLoad() {
         panel.floatingPanel = true
-        
+
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "didBecomeActive", name: NSApplicationDidBecomeActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "willResignActive", name: NSApplicationWillResignActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "didUpdateTitle:", name: "HeliumUpdateTitle", object: nil)
     }
-    
+
     //MARK: IBActions
-    
-    @IBAction func translucencyPress(sender: NSMenuItem) {
-        if sender.state == NSOnState {
-            sender.state = NSOffState
-            didDisableTranslucency()
-        }
-        else {
-            sender.state = NSOnState
-            didEnableTranslucency()
-        }
-    }
-    
+
     @IBAction func percentagePress(sender: NSMenuItem) {
         for button in sender.menu!.itemArray{
             (button as! NSMenuItem).state = NSOffState
@@ -75,49 +64,49 @@ class HeliumPanelController : NSWindowController {
         sender.state = NSOnState
         let value = sender.title.substringToIndex(advance(sender.title.endIndex, -1))
         if let alpha = value.toInt() {
-             didUpdateAlpha(NSNumber(integer: alpha))
+             didUpdateAlpha(NSNumber(integer: alpha));
         }
     }
-    
+
     @IBAction func openLocationPress(sender: AnyObject) {
         didRequestLocation()
     }
-    
+
     @IBAction func openFilePress(sender: AnyObject) {
         didRequestFile()
     }
-        
+
     //MARK: Actual functionality
-    
+
     func didUpdateTitle(notification: NSNotification) {
         if let title = notification.object as? String {
             panel.title = title
         }
     }
-    
+
     func didRequestFile() {
-        
+
         let open = NSOpenPanel()
         open.allowsMultipleSelection = false
         open.canChooseFiles = true
         open.canChooseDirectories = false
-        
+
         if open.runModal() == NSModalResponseOK {
             if let url = open.URL {
                 webViewController.loadURL(url)
             }
         }
     }
-    
-    
+
+
     func didRequestLocation() {
         let alert = NSAlert()
         alert.alertStyle = NSAlertStyle.InformationalAlertStyle
         alert.messageText = "Enter Destination URL"
-        
+
         let urlField = NSTextField()
         urlField.frame = NSRect(x: 0, y: 0, width: 300, height: 20)
-        
+
         alert.accessoryView = urlField
         alert.addButtonWithTitle("Load")
         alert.addButtonWithTitle("Cancel")
@@ -125,37 +114,38 @@ class HeliumPanelController : NSWindowController {
             if response == NSAlertFirstButtonReturn {
                 // Load
                 var text = (alert.accessoryView as! NSTextField).stringValue
-                
+
                 if !(text.lowercaseString.hasPrefix("http://") || text.lowercaseString.hasPrefix("https://")) {
                     text = "http://" + text
                 }
-                
+
                 if let url = NSURL(string: text) {
                     self.webViewController.loadURL(url)
                 }
             }
         })
     }
-    
+
     func didBecomeActive() {
         panel.ignoresMouseEvents = false
     }
-    
+
     func willResignActive() {
         if translucent {
             panel.ignoresMouseEvents = true
         }
     }
-    
+
     func didEnableTranslucency() {
         translucent = true
     }
-    
+
     func didDisableTranslucency() {
         translucent = false
     }
-    
+
     func didUpdateAlpha(newAlpha: NSNumber) {
         alpha = CGFloat(newAlpha.doubleValue) / CGFloat(100.0)
+        translucent = true
     }
 }

--- a/Helium/Helium/HeliumPanelController.swift
+++ b/Helium/Helium/HeliumPanelController.swift
@@ -54,6 +54,13 @@ class HeliumPanelController : NSWindowController {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "willResignActive", name: NSApplicationWillResignActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "didUpdateTitle:", name: "HeliumUpdateTitle", object: nil)
     }
+    
+    func changePercentage (newValue: String) {
+        let value = newValue.substringToIndex(advance(newValue.endIndex, -1))
+        if var alpha = value.toInt() {
+            didUpdateAlpha(NSNumber(integer: alpha));
+        }
+    }
 
     //MARK: IBActions
 
@@ -62,9 +69,11 @@ class HeliumPanelController : NSWindowController {
             (button as! NSMenuItem).state = NSOffState
         }
         sender.state = NSOnState
-        let value = sender.title.substringToIndex(advance(sender.title.endIndex, -1))
-        if let alpha = value.toInt() {
-             didUpdateAlpha(NSNumber(integer: alpha));
+        if sender.title == "Boss Alert" {
+            changePercentage("0%");
+        }
+        else {
+            changePercentage(sender.title);
         }
     }
 


### PR DESCRIPTION
add boss alert:
Press cmd+D (Boss Alert) to completely hide Helium if you're boss is coming and press cmd+F to show it again!

remove translucent menuItem:
As it is strictly linked with opacity, i think it is useless. Just change the opacity and the translucency will activate automatically.
Right now, the user has to perform two actions: change the opacity and then press the "Translucent" item in the menu (or cmd+T).