### PR TITLE
Netflix HTML5 support

### DIFF
--- a/Helium/Helium.xcodeproj/project.pbxproj
+++ b/Helium/Helium.xcodeproj/project.pbxproj
@@ -198,6 +198,8 @@
 		4D867CA91AD6781200681331 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0630;
 				ORGANIZATIONNAME = "Jaden Geller";
 				TargetAttributes = {

--- a/Helium/Helium/AppDelegate.swift
+++ b/Helium/Helium/AppDelegate.swift
@@ -41,12 +41,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // Called when the App opened via URL.
     func handleURLEvent(event: NSAppleEventDescriptor, withReply reply: NSAppleEventDescriptor) {
         if let urlString:String? = event.paramDescriptorForKeyword(AEKeyword(keyDirectObject))?.stringValue {
-            if let url:String? = urlString?.substringFromIndex(advance(urlString!.startIndex,9)){
-                var urlObject:NSURL = NSURL(string:url!)!
+            if let url:String? = urlString?.substringFromIndex(urlString!.startIndex.advancedBy(9)){
+                let urlObject:NSURL = NSURL(string:url!)!
             NSNotificationCenter.defaultCenter().postNotificationName("HeliumLoadURL", object: urlObject)
                 
             }else {
-                println("No valid URL to handle")
+                print("No valid URL to handle")
             }
             
             

--- a/Helium/Helium/HeliumPanelController.swift
+++ b/Helium/Helium/HeliumPanelController.swift
@@ -70,11 +70,11 @@ class HeliumPanelController : NSWindowController {
     
     @IBAction func percentagePress(sender: NSMenuItem) {
         for button in sender.menu!.itemArray{
-            (button as! NSMenuItem).state = NSOffState
+            (button ).state = NSOffState
         }
         sender.state = NSOnState
-        let value = sender.title.substringToIndex(advance(sender.title.endIndex, -1))
-        if let alpha = value.toInt() {
+        let value = sender.title.substringToIndex(sender.title.endIndex.advancedBy(-1))
+        if let alpha = Int(value) {
              didUpdateAlpha(NSNumber(integer: alpha))
         }
     }

--- a/Helium/Helium/WebViewController.swift
+++ b/Helium/Helium/WebViewController.swift
@@ -25,7 +25,7 @@ class WebViewController: NSViewController, WKNavigationDelegate {
         webView.configuration.preferences.plugInsEnabled = true
         
         // Netflix support via Silverlight (HTML5 Netflix doesn't work for some unknown reason)
-        webView._customUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_0) AppleWebKit/600.5.17 (KHTML, like Gecko) Version/7.1.5 Safari/537.85.14"
+        webView._customUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12"
         
         // Setup magic URLs
         webView.navigationDelegate = self

--- a/Helium/Helium/WebViewController.swift
+++ b/Helium/Helium/WebViewController.swift
@@ -19,7 +19,7 @@ class WebViewController: NSViewController, WKNavigationDelegate {
         // Layout webview
         view.addSubview(webView)
         webView.frame = view.bounds
-        webView.autoresizingMask = NSAutoresizingMaskOptions.ViewHeightSizable | NSAutoresizingMaskOptions.ViewWidthSizable
+        webView.autoresizingMask = [NSAutoresizingMaskOptions.ViewHeightSizable, NSAutoresizingMaskOptions.ViewWidthSizable]
         
         // Allow plug-ins such as silverlight
         webView.configuration.preferences.plugInsEnabled = true
@@ -149,7 +149,7 @@ class WebViewController: NSViewController, WKNavigationDelegate {
         }
     }
     
-    override func observeValueForKeyPath(keyPath: String, ofObject object: AnyObject, change: [NSObject : AnyObject], context: UnsafeMutablePointer<Void>) {
+    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
         
         if object as! NSObject == webView && keyPath == "estimatedProgress" {
             if let progress = change["new"] as? Float {

--- a/Helium/Helium/WebViewController.swift
+++ b/Helium/Helium/WebViewController.swift
@@ -24,7 +24,7 @@ class WebViewController: NSViewController, WKNavigationDelegate {
         // Allow plug-ins such as silverlight
         webView.configuration.preferences.plugInsEnabled = true
         
-        // Netflix support via Silverlight (HTML5 Netflix doesn't work for some unknown reason)
+        // Custom user agent string for Netflix HTML5 support
         webView._customUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12"
         
         // Setup magic URLs


### PR DESCRIPTION
Changed the user agent to the one currently used by Safari. Netflix now works with HTML5, but the application asks to have access to a keychain item (if I remember correctly, couldn't reproduce this. I assume this only appears at first launch, and with exported application. Nothing was asked when running from Xcode, and the playback worked fine). Pressing "Allow" on this continues to bring up the permission request, but pressing "Always allow" hides it and the playback starts.

This should fix #54 