### PR TITLE
Single line break mode in textfield

### DIFF
--- a/Helium/Helium/HeliumPanelController.swift
+++ b/Helium/Helium/HeliumPanelController.swift
@@ -117,6 +117,8 @@ class HeliumPanelController : NSWindowController {
         
         let urlField = NSTextField()
         urlField.frame = NSRect(x: 0, y: 0, width: 300, height: 20)
+        urlField.lineBreakMode = NSLineBreakMode.ByTruncatingHead
+        urlField.usesSingleLineMode = true
         
         alert.accessoryView = urlField
         alert.addButtonWithTitle("Load")


### PR DESCRIPTION
URLs that are longer than the width of the text box or have a new line are now displayed in a single line.