### PR TITLE
Update to latest Swift, add fullscreen support

### DIFF
--- a/Helium/Helium.xcodeproj/project.pbxproj
+++ b/Helium/Helium.xcodeproj/project.pbxproj
@@ -198,7 +198,9 @@
 		4D867CA91AD6781200681331 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Jaden Geller";
 				TargetAttributes = {
 					4D867CB01AD6781200681331 = {
@@ -311,6 +313,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -383,6 +386,7 @@
 				INFOPLIST_FILE = Helium/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				OTHER_LDFLAGS = "-Wl,-rpath,@loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.JadenGeller.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Helium/Helium-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -402,6 +406,7 @@
 				INFOPLIST_FILE = Helium/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				OTHER_LDFLAGS = "-Wl,-rpath,@loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.JadenGeller.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Helium/Helium-Bridging-Header.h";
 			};
@@ -422,6 +427,7 @@
 				);
 				INFOPLIST_FILE = HeliumTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.JadenGeller.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Helium.app/Contents/MacOS/Helium";
 			};
@@ -438,6 +444,7 @@
 				);
 				INFOPLIST_FILE = HeliumTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.JadenGeller.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Helium.app/Contents/MacOS/Helium";
 			};

--- a/Helium/Helium/AppDelegate.swift
+++ b/Helium/Helium/AppDelegate.swift
@@ -40,9 +40,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         if let urlString:String? = event.paramDescriptorForKeyword(AEKeyword(keyDirectObject))?.stringValue {
             if let url:String? = urlString?.substringFromIndex(urlString!.startIndex.advancedBy(prefixLength)) {
                 let urlObject:NSURL = NSURL(string:url!)!
+                NSLog("Loading %@", url!)
                 NSNotificationCenter.defaultCenter().postNotificationName("HeliumLoadURL", object: urlObject)
             } else {
-                print("No valid URL to handle", terminator: "")
+                NSLog("No valid URL to handle")
             }
         }
     }

--- a/Helium/Helium/AppDelegate.swift
+++ b/Helium/Helium/AppDelegate.swift
@@ -23,7 +23,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             forEventClass: AEEventClass(kInternetEventClass),
             andEventID: AEEventID(kAEGetURL)
         )
-        
     }
 
     func applicationWillTerminate(aNotification: NSNotification) {
@@ -35,18 +34,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         sender.state = (sender.state == NSOnState) ? NSOffState : NSOnState
         NSUserDefaults.standardUserDefaults().setBool((sender.state == NSOffState), forKey: "disabledMagicURLs")
     }
-    
-    
-//MARK: - handleURLEvent
+
+    //MARK: - handleURLEvent
     // Called when the App opened via URL.
     func handleURLEvent(event: NSAppleEventDescriptor, withReply reply: NSAppleEventDescriptor) {
         if let urlString:String? = event.paramDescriptorForKeyword(AEKeyword(keyDirectObject))?.stringValue {
-            if let url:String? = urlString?.substringFromIndex(advance(urlString!.startIndex,9)){
-                var urlObject:NSURL = NSURL(string:url!)!
+            if let url:String? = urlString?.substringFromIndex(urlString!.startIndex.advancedBy(9)){
+                let urlObject:NSURL = NSURL(string:url!)!
             NSNotificationCenter.defaultCenter().postNotificationName("HeliumLoadURL", object: urlObject)
                 
             }else {
-                println("No valid URL to handle")
+                print("No valid URL to handle", terminator: "")
             }
             
             

--- a/Helium/Helium/AppDelegate.swift
+++ b/Helium/Helium/AppDelegate.swift
@@ -36,8 +36,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     //MARK: - handleURLEvent
     // Called when the App opened via URL.
     func handleURLEvent(event: NSAppleEventDescriptor, withReply reply: NSAppleEventDescriptor) {
+        let prefixLength = "helium://".lengthOfBytesUsingEncoding(NSASCIIStringEncoding)
         if let urlString:String? = event.paramDescriptorForKeyword(AEKeyword(keyDirectObject))?.stringValue {
-            if let url:String? = urlString?.substringFromIndex(urlString!.startIndex.advancedBy(9)) {
+            if let url:String? = urlString?.substringFromIndex(urlString!.startIndex.advancedBy(prefixLength)) {
                 let urlObject:NSURL = NSURL(string:url!)!
                 NSNotificationCenter.defaultCenter().postNotificationName("HeliumLoadURL", object: urlObject)
             } else {

--- a/Helium/Helium/AppDelegate.swift
+++ b/Helium/Helium/AppDelegate.swift
@@ -12,9 +12,8 @@ import Cocoa
 class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     @IBOutlet weak var magicURLMenu: NSMenuItem!
-    
+
     func applicationDidFinishLaunching(aNotification: NSNotification) {
-        
         // Insert code here to initialize your application
         magicURLMenu.state = NSUserDefaults.standardUserDefaults().boolForKey("disabledMagicURLs") ? NSOffState : NSOnState
         NSAppleEventManager.sharedAppleEventManager().setEventHandler(
@@ -28,8 +27,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     func applicationWillTerminate(aNotification: NSNotification) {
         // Insert code here to tear down your application
     }
-    
-    
+
     @IBAction func magicURLRedirectToggled(sender: NSMenuItem) {
         sender.state = (sender.state == NSOnState) ? NSOffState : NSOnState
         NSUserDefaults.standardUserDefaults().setBool((sender.state == NSOffState), forKey: "disabledMagicURLs")
@@ -39,15 +37,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // Called when the App opened via URL.
     func handleURLEvent(event: NSAppleEventDescriptor, withReply reply: NSAppleEventDescriptor) {
         if let urlString:String? = event.paramDescriptorForKeyword(AEKeyword(keyDirectObject))?.stringValue {
-            if let url:String? = urlString?.substringFromIndex(urlString!.startIndex.advancedBy(9)){
+            if let url:String? = urlString?.substringFromIndex(urlString!.startIndex.advancedBy(9)) {
                 let urlObject:NSURL = NSURL(string:url!)!
-            NSNotificationCenter.defaultCenter().postNotificationName("HeliumLoadURL", object: urlObject)
-                
-            }else {
+                NSNotificationCenter.defaultCenter().postNotificationName("HeliumLoadURL", object: urlObject)
+            } else {
                 print("No valid URL to handle", terminator: "")
             }
-            
-            
         }
     }
 }

--- a/Helium/Helium/Base.lproj/Main.storyboard
+++ b/Helium/Helium/Base.lproj/Main.storyboard
@@ -284,9 +284,9 @@ CA
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController storyboardIdentifier="HeliumController" showSeguePresentationStyle="single" id="B8D-0N-5wS" customClass="HeliumPanelController" customModule="Helium" customModuleProvider="target" sceneMemberID="viewController">
-                    <window key="window" title="Helium" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA" customClass="NSPanel">
-                        <windowStyleMask key="styleMask" titled="YES" resizable="YES" utility="YES" HUD="YES"/>
-                        <windowCollectionBehavior key="collectionBehavior" moveToActiveSpace="YES"/>
+                    <window key="window" title="Helium" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hasShadow="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA" customClass="NSPanel">
+                        <windowStyleMask key="styleMask" titled="YES" resizable="YES" utility="YES" nonactivatingPanel="YES" HUD="YES"/>
+                        <windowCollectionBehavior key="collectionBehavior" canJoinAllSpaces="YES" stationary="YES" fullScreenAuxiliary="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
@@ -306,6 +306,7 @@ CA
                     <view key="view" id="m2S-Jp-Qdl">
                         <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <animations/>
                     </view>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/Helium/Helium/Base.lproj/Main.storyboard
+++ b/Helium/Helium/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14D131" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="15A284" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7531"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
     </dependencies>
     <scenes>
         <!--Application-->

--- a/Helium/Helium/HeliumPanelController.swift
+++ b/Helium/Helium/HeliumPanelController.swift
@@ -17,7 +17,7 @@ class HeliumPanelController : NSWindowController {
             }
         }
     }
-    
+
     var translucent: Bool = false {
         didSet {
             if !NSApplication.sharedApplication().active {
@@ -33,14 +33,13 @@ class HeliumPanelController : NSWindowController {
             }
         }
     }
-    
-    
+
     var panel: NSPanel! {
         get {
             return (self.window as! NSPanel)
         }
     }
-    
+
     var webViewController: WebViewController {
         get {
             return self.window?.contentViewController as! WebViewController
@@ -49,14 +48,13 @@ class HeliumPanelController : NSWindowController {
 
     override func windowDidLoad() {
         panel.floatingPanel = true
-        
+
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "didBecomeActive", name: NSApplicationDidBecomeActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "willResignActive", name: NSApplicationWillResignActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "didUpdateTitle:", name: "HeliumUpdateTitle", object: nil)
     }
-    
+
     //MARK: IBActions
-    
     @IBAction func translucencyPress(sender: NSMenuItem) {
         if sender.state == NSOnState {
             sender.state = NSOffState
@@ -67,7 +65,7 @@ class HeliumPanelController : NSWindowController {
             didEnableTranslucency()
         }
     }
-    
+
     @IBAction func percentagePress(sender: NSMenuItem) {
         for button in sender.menu!.itemArray {
             button.state = NSOffState
@@ -78,45 +76,44 @@ class HeliumPanelController : NSWindowController {
              didUpdateAlpha(NSNumber(integer: alpha))
         }
     }
-    
+
     @IBAction func openLocationPress(sender: AnyObject) {
         didRequestLocation()
     }
-    
+
     @IBAction func openFilePress(sender: AnyObject) {
         didRequestFile()
     }
-    
+
     //MARK: Actual functionality
     func didUpdateTitle(notification: NSNotification) {
         if let title = notification.object as? String {
             panel.title = title
         }
     }
-    
+
     func didRequestFile() {
-        
+
         let open = NSOpenPanel()
         open.allowsMultipleSelection = false
         open.canChooseFiles = true
         open.canChooseDirectories = false
-        
+
         if open.runModal() == NSModalResponseOK {
             if let url = open.URL {
                 webViewController.loadURL(url)
             }
         }
     }
-    
-    
+
     func didRequestLocation() {
         let alert = NSAlert()
         alert.alertStyle = NSAlertStyle.InformationalAlertStyle
         alert.messageText = "Enter Destination URL"
-        
+
         let urlField = NSTextField()
         urlField.frame = NSRect(x: 0, y: 0, width: 300, height: 20)
-        
+
         alert.accessoryView = urlField
         alert.addButtonWithTitle("Load")
         alert.addButtonWithTitle("Cancel")
@@ -124,36 +121,36 @@ class HeliumPanelController : NSWindowController {
             if response == NSAlertFirstButtonReturn {
                 // Load
                 var text = (alert.accessoryView as! NSTextField).stringValue
-                
+
                 if !(text.lowercaseString.hasPrefix("http://") || text.lowercaseString.hasPrefix("https://")) {
                     text = "http://" + text
                 }
-                
+
                 if let url = NSURL(string: text) {
                     self.webViewController.loadURL(url)
                 }
             }
         })
     }
-    
+
     func didBecomeActive() {
         panel.ignoresMouseEvents = false
     }
-    
+
     func willResignActive() {
         if translucent {
             panel.ignoresMouseEvents = true
         }
     }
-    
+
     func didEnableTranslucency() {
         translucent = true
     }
-    
+
     func didDisableTranslucency() {
         translucent = false
     }
-    
+
     func didUpdateAlpha(newAlpha: NSNumber) {
         alpha = CGFloat(newAlpha.doubleValue) / CGFloat(100.0)
     }

--- a/Helium/Helium/HeliumPanelController.swift
+++ b/Helium/Helium/HeliumPanelController.swift
@@ -46,7 +46,7 @@ class HeliumPanelController : NSWindowController {
             return self.window?.contentViewController as! WebViewController
         }
     }
-    
+
     override func windowDidLoad() {
         panel.floatingPanel = true
         
@@ -69,12 +69,12 @@ class HeliumPanelController : NSWindowController {
     }
     
     @IBAction func percentagePress(sender: NSMenuItem) {
-        for button in sender.menu!.itemArray{
-            (button as! NSMenuItem).state = NSOffState
+        for button in sender.menu!.itemArray {
+            button.state = NSOffState
         }
         sender.state = NSOnState
-        let value = sender.title.substringToIndex(advance(sender.title.endIndex, -1))
-        if let alpha = value.toInt() {
+        let value = sender.title.substringToIndex(sender.title.endIndex.advancedBy(-1))
+        if let alpha = Int(value) {
              didUpdateAlpha(NSNumber(integer: alpha))
         }
     }
@@ -86,9 +86,8 @@ class HeliumPanelController : NSWindowController {
     @IBAction func openFilePress(sender: AnyObject) {
         didRequestFile()
     }
-        
-    //MARK: Actual functionality
     
+    //MARK: Actual functionality
     func didUpdateTitle(notification: NSNotification) {
         if let title = notification.object as? String {
             panel.title = title

--- a/Helium/Helium/Info.plist
+++ b/Helium/Helium/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.JadenGeller.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Helium/Helium/WebViewController.swift
+++ b/Helium/Helium/WebViewController.swift
@@ -10,35 +10,35 @@ import Cocoa
 import WebKit
 
 class WebViewController: NSViewController, WKNavigationDelegate {
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "loadURLObject:", name: "HeliumLoadURL", object: nil)
-        
+
         // Layout webview
         view.addSubview(webView)
         webView.frame = view.bounds
         webView.autoresizingMask = [NSAutoresizingMaskOptions.ViewHeightSizable, NSAutoresizingMaskOptions.ViewWidthSizable]
-        
+
         // Allow plug-ins such as silverlight
         webView.configuration.preferences.plugInsEnabled = true
-        
+
         // Netflix support via Silverlight (HTML5 Netflix doesn't work for some unknown reason)
         webView._customUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_0) AppleWebKit/600.5.17 (KHTML, like Gecko) Version/7.1.5 Safari/537.85.14"
-        
+
         // Setup magic URLs
         webView.navigationDelegate = self
-        
+
         // Allow zooming
         webView.allowsMagnification = true
-        
+
         // Listen for load progress
         webView.addObserver(self, forKeyPath: "estimatedProgress", options: NSKeyValueObservingOptions.New, context: nil)
-        
+
         clear()
     }
-    
+
     override func validateMenuItem(menuItem: NSMenuItem) -> Bool{
         switch menuItem.title {
         case "Back":
@@ -49,85 +49,88 @@ class WebViewController: NSViewController, WKNavigationDelegate {
             return true
         }
     }
-    
+
     @IBAction func backPress(sender: AnyObject) {
         webView.goBack()
     }
-    
+
     @IBAction func forwardPress(sender: AnyObject) {
         webView.goForward()
     }
-    
+
     func zoomIn() {
         webView.magnification += 0.1
     }
-    
+
     func zoomOut() {
         webView.magnification -= 0.1
     }
-    
+
     func resetZoom() {
         webView.magnification = 1
     }
-    
+
     @IBAction func reloadPress(sender: AnyObject) {
         requestedReload()
     }
-    
+
     @IBAction func clearPress(sender: AnyObject) {
         clear()
     }
-    
+
     @IBAction func resetZoomLevel(sender: AnyObject) {
         resetZoom()
     }
+
     @IBAction func zoomIn(sender: AnyObject) {
         zoomIn()
     }
+
     @IBAction func zoomOut(sender: AnyObject) {
         zoomOut()
     }
-
 
     override var representedObject: AnyObject? {
         didSet {
         // Update the view, if already loaded.
         }
     }
-    
+
     func loadURL(url:NSURL) {
         webView.loadRequest(NSURLRequest(URL: url))
     }
-    
-//MARK: - loadURLObject
+
+    //MARK: - loadURLObject
     func loadURLObject(urlObject : NSNotification) {
         if let url = urlObject.object as? NSURL {
             loadURL(url);
         }
     }
-    
+
     func requestedReload() {
         webView.reload()
     }
+
     func clear() {
         loadURL(NSURL(string: "https://cdn.rawgit.com/JadenGeller/Helium/master/helium_start.html")!)
     }
 
     var webView = WKWebView()
+
     var shouldRedirect: Bool {
         get {
             return !NSUserDefaults.standardUserDefaults().boolForKey("disabledMagicURLs")
         }
     }
-    
+
     // Redirect Hulu and YouTube to pop-out videos
     func webView(webView: WKWebView, decidePolicyForNavigationAction navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {
-        
+
         if shouldRedirect, let url = navigationAction.request.URL, let urlString: String! = url.absoluteString {
             var modified = urlString
             modified = modified.replacePrefix("https://www.youtube.com/watch?", replacement: "https://www.youtube.com/watch_popup?")
             modified = modified.replacePrefix("https://vimeo.com/", replacement: "http://player.vimeo.com/video/")
-            
+
             modified = modified.replacePrefix("http://v.youku.com/v_show/id_", replacement: "http://player.youku.com/embed/")
 
             if urlString != modified {
@@ -136,10 +139,10 @@ class WebViewController: NSViewController, WKNavigationDelegate {
                 return
             }
         }
-        
+
         decisionHandler(WKNavigationActionPolicy.Allow)
     }
-    
+
     func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation) {
         if let pageTitle = webView.title {
             var title = pageTitle;
@@ -148,9 +151,9 @@ class WebViewController: NSViewController, WKNavigationDelegate {
             NSNotificationCenter.defaultCenter().postNotification(notif)
         }
     }
-    
+
     override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]!, context: UnsafeMutablePointer<Void>) {
-        
+
         if object as! NSObject == webView && keyPath == "estimatedProgress" {
             if let progress = change["new"] as? Float {
                 let percent = progress * 100
@@ -158,13 +161,11 @@ class WebViewController: NSViewController, WKNavigationDelegate {
                 if percent == 100 {
                     title = "Helium"
                 }
-                
+
                 let notif = NSNotification(name: "HeliumUpdateTitle", object: title);
                 NSNotificationCenter.defaultCenter().postNotification(notif)
             }
         }
-        
-        
     }
 }
 
@@ -176,6 +177,5 @@ extension String {
         else {
             return self
         }
-    
     }
 }

--- a/Helium/Helium/WebViewController.swift
+++ b/Helium/Helium/WebViewController.swift
@@ -19,7 +19,7 @@ class WebViewController: NSViewController, WKNavigationDelegate {
         // Layout webview
         view.addSubview(webView)
         webView.frame = view.bounds
-        webView.autoresizingMask = NSAutoresizingMaskOptions.ViewHeightSizable | NSAutoresizingMaskOptions.ViewWidthSizable
+        webView.autoresizingMask = [NSAutoresizingMaskOptions.ViewHeightSizable, NSAutoresizingMaskOptions.ViewWidthSizable]
         
         // Allow plug-ins such as silverlight
         webView.configuration.preferences.plugInsEnabled = true
@@ -123,7 +123,7 @@ class WebViewController: NSViewController, WKNavigationDelegate {
     // Redirect Hulu and YouTube to pop-out videos
     func webView(webView: WKWebView, decidePolicyForNavigationAction navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {
         
-        if shouldRedirect, let url = navigationAction.request.URL, let urlString = url.absoluteString {
+        if shouldRedirect, let url = navigationAction.request.URL, let urlString: String! = url.absoluteString {
             var modified = urlString
             modified = modified.replacePrefix("https://www.youtube.com/watch?", replacement: "https://www.youtube.com/watch_popup?")
             modified = modified.replacePrefix("https://vimeo.com/", replacement: "http://player.vimeo.com/video/")
@@ -149,7 +149,7 @@ class WebViewController: NSViewController, WKNavigationDelegate {
         }
     }
     
-    override func observeValueForKeyPath(keyPath: String, ofObject object: AnyObject, change: [NSObject : AnyObject], context: UnsafeMutablePointer<Void>) {
+    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]!, context: UnsafeMutablePointer<Void>) {
         
         if object as! NSObject == webView && keyPath == "estimatedProgress" {
             if let progress = change["new"] as? Float {

--- a/Helium/HeliumTests/Info.plist
+++ b/Helium/HeliumTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.JadenGeller.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Duplicate of #97. I screwed up the git history over there.

That is, it can now float over fullscreen apps.

Most of the Swift updates came automagically from Xcode; I hope they don't clobber any backwards compatibility.

_Here's a cute animal picture for your trouble:_

![baby giraffe](https://s-media-cache-ak0.pinimg.com/736x/7c/9a/e6/7c9ae6c0b4c682a26a3482da93a6cfc1.jpg)