### PR TITLE
Add preference to float over full screen apps

### DIFF
--- a/Helium/Helium/AppDelegate.swift
+++ b/Helium/Helium/AppDelegate.swift
@@ -12,6 +12,7 @@ import Cocoa
 class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     @IBOutlet weak var magicURLMenu: NSMenuItem!
+    @IBOutlet weak var fullScreenFloatMenu: NSMenuItem!
 
     func applicationWillFinishLaunching(notification: NSNotification) {
         NSAppleEventManager.sharedAppleEventManager().setEventHandler(
@@ -24,6 +25,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     func applicationDidFinishLaunching(aNotification: NSNotification) {
         magicURLMenu.state = NSUserDefaults.standardUserDefaults().boolForKey("disabledMagicURLs") ? NSOffState : NSOnState
+        
+        fullScreenFloatMenu.state = NSUserDefaults.standardUserDefaults().boolForKey("disabledFullScreenFloat") ? NSOffState : NSOnState
     }
 
     func applicationWillTerminate(aNotification: NSNotification) {

--- a/Helium/Helium/Base.lproj/Main.storyboard
+++ b/Helium/Helium/Base.lproj/Main.storyboard
@@ -31,6 +31,12 @@
                                                             <action selector="magicURLRedirectToggled:" target="Voe-Tx-rLC" id="OyL-id-RDj"/>
                                                         </connections>
                                                     </menuItem>
+                                                    <menuItem title="Float over Full Screen Apps" state="on" id="J8Z-sv-9PI" userLabel="Float over Full Screen Apps Menu">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="floatOverFullScreenAppsToggled:" target="Ady-hI-5gd" id="WlK-rI-bD7"/>
+                                                        </connections>
+                                                    </menuItem>
                                                 </items>
                                             </menu>
                                         </menuItem>
@@ -300,6 +306,7 @@ CA
                 </application>
                 <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Helium" customModuleProvider="target">
                     <connections>
+                        <outlet property="fullScreenFloatMenu" destination="J8Z-sv-9PI" id="8gu-KT-nBS"/>
                         <outlet property="magicURLMenu" destination="Vn0-wi-SSU" id="jow-sG-Fmx"/>
                     </connections>
                 </customObject>
@@ -313,7 +320,7 @@ CA
             <objects>
                 <windowController storyboardIdentifier="HeliumController" showSeguePresentationStyle="single" id="B8D-0N-5wS" customClass="HeliumPanelController" customModule="Helium" customModuleProvider="target" sceneMemberID="viewController">
                     <window key="window" title="Helium" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA" customClass="NSPanel">
-                        <windowStyleMask key="styleMask" titled="YES" resizable="YES" utility="YES" HUD="YES"/>
+                        <windowStyleMask key="styleMask" titled="YES" resizable="YES" utility="YES" nonactivatingPanel="YES" HUD="YES"/>
                         <windowCollectionBehavior key="collectionBehavior" moveToActiveSpace="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>

--- a/Helium/Helium/HeliumPanelController.swift
+++ b/Helium/Helium/HeliumPanelController.swift
@@ -103,6 +103,17 @@ class HeliumPanelController : NSWindowController {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "didBecomeActive", name: NSApplicationDidBecomeActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "willResignActive", name: NSApplicationWillResignActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "didUpdateTitle:", name: "HeliumUpdateTitle", object: nil)
+        
+            setFloatOverFullScreenApps()
+    }
+    
+    func setFloatOverFullScreenApps() {
+        if NSUserDefaults.standardUserDefaults().boolForKey("disabledFullScreenFloat") {
+            panel.collectionBehavior = [.MoveToActiveSpace, .FullScreenAuxiliary]
+
+        } else {
+            panel.collectionBehavior = [.CanJoinAllSpaces, .FullScreenAuxiliary]
+        }
     }
     
     //MARK: IBActions
@@ -159,7 +170,14 @@ class HeliumPanelController : NSWindowController {
     @IBAction func openFilePress(sender: AnyObject) {
         didRequestFile()
     }
+    
+    @IBAction func floatOverFullScreenAppsToggled(sender: NSMenuItem) {
+        sender.state = (sender.state == NSOnState) ? NSOffState : NSOnState
+        NSUserDefaults.standardUserDefaults().setBool((sender.state == NSOffState), forKey: "disabledFullScreenFloat")
         
+        setFloatOverFullScreenApps()
+    }
+    
     //MARK: Actual functionality
     
     func didUpdateTitle(notification: NSNotification) {


### PR DESCRIPTION
Continued from #100. I added full screen support as a preference under Helium > Preferences... > Float over Full Screen Apps. The preference is enabled by default. I'm not very familiar with swift so my method might not be the best.

<img width="478" alt="screen shot 2015-10-27 at 10 32 32 pm" src="https://cloud.githubusercontent.com/assets/6983821/10778273/aec850f2-7cfa-11e5-8c3f-1350a440d0ce.png">