### PR TITLE
Custom YouTube Video start-time support.

### DIFF
--- a/Helium/Helium/WebViewController.swift
+++ b/Helium/Helium/WebViewController.swift
@@ -99,6 +99,8 @@ class WebViewController: NSViewController, WKNavigationDelegate {
         }
     }
     
+    var uneditedURL:String!
+    
     func loadAlmostURL(var text: String) {
         if !(text.lowercaseString.hasPrefix("http://") || text.lowercaseString.hasPrefix("https://")) {
             text = "http://" + text
@@ -107,6 +109,8 @@ class WebViewController: NSViewController, WKNavigationDelegate {
         if let url = NSURL(string: text) {
             loadURL(url)
         }
+        
+        self.uneditedURL = text
     }
     
     func loadURL(url:NSURL) {
@@ -144,8 +148,8 @@ class WebViewController: NSViewController, WKNavigationDelegate {
             modified = modified.replacePrefix("https://vimeo.com/", replacement: "http://player.vimeo.com/video/")
             modified = modified.replacePrefix("http://v.youku.com/v_show/id_", replacement: "http://player.youku.com/embed/")
             
-            if modified.containsString("https://www.youtube.com") {
-                modified = makeCustomStartTimeURL(modified)
+            if self.uneditedURL.containsString("https://www.youtube.com") {
+                modified = makeCustomStartTimeURL(uneditedURL)
             }
 
             if urlString != modified {

--- a/Helium/Helium/WebViewController.swift
+++ b/Helium/Helium/WebViewController.swift
@@ -148,8 +148,10 @@ class WebViewController: NSViewController, WKNavigationDelegate {
             modified = modified.replacePrefix("https://vimeo.com/", replacement: "http://player.vimeo.com/video/")
             modified = modified.replacePrefix("http://v.youku.com/v_show/id_", replacement: "http://player.youku.com/embed/")
             
-            if self.uneditedURL.containsString("https://www.youtube.com") {
-                modified = makeCustomStartTimeURL(uneditedURL)
+        if self.uneditedURL.containsString("https://youtu.be") {
+                if urlString.containsString("?t=") {
+                    modified = "https://youtube.com/embed/" + getVideoHash(urlString) + makeCustomStartTimeURL(urlString)
+                }
             }
 
             if urlString != modified {
@@ -202,7 +204,7 @@ class WebViewController: NSViewController, WKNavigationDelegate {
             let secondsDigits = timing.indexOf("s")
             
             returnURL.removeRange(Range<String.Index>(start: returnURL.startIndex.advancedBy(idx+1), end: returnURL.endIndex))
-            returnURL = returnURL + "start="
+            returnURL = "?start="
             
             //If there are no h/m/s params and only seconds (i.e. ...?t=89)
             if (hoursDigits == -1 && minutesDigits == -1 && secondsDigits == -1) {
@@ -210,6 +212,7 @@ class WebViewController: NSViewController, WKNavigationDelegate {
                 returnURL = returnURL + onlySeconds
                 return returnURL
             }
+            
             //Do check to see if there is an hours parameter.
             var hours = 0
             if (hoursDigits != -1) {
@@ -233,10 +236,19 @@ class WebViewController: NSViewController, WKNavigationDelegate {
             }
             
             //Combine all to make seconds.
-            var secondsFinal = 3600*hours + 60*minutes + seconds
+            let secondsFinal = 3600*hours + 60*minutes + seconds
             returnURL = returnURL + String(secondsFinal)
+            
             return returnURL
         }
+    }
+    
+    //Helper function to return the hash of the video for encoding a popout video that has a start time code.
+    func getVideoHash(url: String) -> String {
+        let startOfHash = url.indexOf(".be/")
+        let endOfHash = url.indexOf("?t")
+        let hash = url.substringWithRange(Range<String.Index>(start: url.startIndex.advancedBy(startOfHash+4), end: url.startIndex.advancedBy(endOfHash)))
+        return hash
     }
 }
 

--- a/Helium/Helium/WebViewController.swift
+++ b/Helium/Helium/WebViewController.swift
@@ -142,7 +142,9 @@ class WebViewController: NSViewController, WKNavigationDelegate {
             var modified = urlString
             modified = modified.replacePrefix("https://www.youtube.com/watch?", replacement: "https://www.youtube.com/watch_popup?")
             modified = modified.replacePrefix("https://vimeo.com/", replacement: "http://player.vimeo.com/video/")
-            modified = makeCustomStartTimeURL(modified)
+            if modified.containsString("https://www.youtube.com") {
+                modified = makeCustomStartTimeURL(modified)
+            }
             modified = modified.replacePrefix("http://v.youku.com/v_show/id_", replacement: "http://player.youku.com/embed/")
 
             if urlString != modified {

--- a/Helium/Helium/WebViewController.swift
+++ b/Helium/Helium/WebViewController.swift
@@ -142,10 +142,11 @@ class WebViewController: NSViewController, WKNavigationDelegate {
             var modified = urlString
             modified = modified.replacePrefix("https://www.youtube.com/watch?", replacement: "https://www.youtube.com/watch_popup?")
             modified = modified.replacePrefix("https://vimeo.com/", replacement: "http://player.vimeo.com/video/")
+            modified = modified.replacePrefix("http://v.youku.com/v_show/id_", replacement: "http://player.youku.com/embed/")
+            
             if modified.containsString("https://www.youtube.com") {
                 modified = makeCustomStartTimeURL(modified)
             }
-            modified = modified.replacePrefix("http://v.youku.com/v_show/id_", replacement: "http://player.youku.com/embed/")
 
             if urlString != modified {
                 decisionHandler(WKNavigationActionPolicy.Cancel)


### PR DESCRIPTION
Fix #125. Added support for YouTube videos with URLs that start at a specific time in the video. More specifically, videos with URL's like so: `https://youtu.be/vb1MiDOd30M?t=1m4s` are converted to YouTube popout URL's that have time encoded only in seconds like this: `https://youtube.com/embed/vb1MiDOd30M?start=64`.