### PR TITLE
Customizable Home Page

### DIFF
--- a/Helium/Helium/HeliumPanelController.swift
+++ b/Helium/Helium/HeliumPanelController.swift
@@ -245,20 +245,33 @@ class HeliumPanelController : NSWindowController {
         alert.addButtonWithTitle("Cancel")
         alert.beginSheetModalForWindow(self.window!, completionHandler: { response in
             if response == NSAlertFirstButtonReturn {
-                let text = (alert.accessoryView as! NSTextField).stringValue
+                var text = (alert.accessoryView as! NSTextField).stringValue
+                
+                // Add prefix if necessary
+                if !(text.lowercaseString.hasPrefix("http://") || text.lowercaseString.hasPrefix("https://")) {
+                    text = "http://" + text
+                }
 
-                // Save to defaults
-                if text != "" {
+                // Save to defaults if valid. Else, use Helium default page
+                if self.validateURL(text) {
                     NSUserDefaults.standardUserDefaults().setObject(text, forKey: UserSetting.HomePageURL.userDefaultsKey)
                 }
                 else{
                     NSUserDefaults.standardUserDefaults().setObject("https://cdn.rawgit.com/JadenGeller/Helium/master/helium_start.html", forKey: UserSetting.HomePageURL.userDefaultsKey)
                 }
                 
-                // Load
+                // Load new Home page
                 self.webViewController.loadAlmostURL(NSUserDefaults.standardUserDefaults().stringForKey(UserSetting.HomePageURL.userDefaultsKey)!)
             }
         })
+    }
+    
+    func validateURL (stringURL : NSString) -> Bool {
+        
+        let urlRegEx = "((https|http)://)((\\w|-)+)(([.]|[/])((\\w|-)+))+"
+        let predicate = NSPredicate(format:"SELF MATCHES %@", argumentArray:[urlRegEx])
+        
+        return predicate.evaluateWithObject(stringURL)
     }
         
     func didBecomeActive() {

--- a/Helium/Helium/HeliumPanelController.swift
+++ b/Helium/Helium/HeliumPanelController.swift
@@ -266,7 +266,7 @@ class HeliumPanelController : NSWindowController {
         })
     }
     
-    func validateURL (stringURL : NSString) -> Bool {
+    func validateURL (stringURL : String) -> Bool {
         
         let urlRegEx = "((https|http)://)((\\w|-)+)(([.]|[/])((\\w|-)+))+"
         let predicate = NSPredicate(format:"SELF MATCHES %@", argumentArray:[urlRegEx])

--- a/Helium/Helium/HeliumPanelController.swift
+++ b/Helium/Helium/HeliumPanelController.swift
@@ -181,6 +181,10 @@ class HeliumPanelController : NSWindowController {
         setFloatOverFullScreenApps()
     }
     
+    @IBAction func setHomePage(sender: AnyObject){
+        didRequestChangeHomepage()
+    }
+    
     //MARK: Actual functionality
     
     func didUpdateTitle(notification: NSNotification) {
@@ -226,6 +230,37 @@ class HeliumPanelController : NSWindowController {
         })
     }
     
+    func didRequestChangeHomepage(){
+        let alert = NSAlert()
+        alert.alertStyle = NSAlertStyle.InformationalAlertStyle
+        alert.messageText = "Enter new Home Page URL"
+        
+        let urlField = NSTextField()
+        urlField.frame = NSRect(x: 0, y: 0, width: 300, height: 20)
+        urlField.lineBreakMode = NSLineBreakMode.ByTruncatingHead
+        urlField.usesSingleLineMode = true
+        
+        alert.accessoryView = urlField
+        alert.addButtonWithTitle("Set")
+        alert.addButtonWithTitle("Cancel")
+        alert.beginSheetModalForWindow(self.window!, completionHandler: { response in
+            if response == NSAlertFirstButtonReturn {
+                let text = (alert.accessoryView as! NSTextField).stringValue
+
+                // Save to defaults
+                if text != "" {
+                    NSUserDefaults.standardUserDefaults().setObject(text, forKey: UserSetting.HomePageURL.userDefaultsKey)
+                }
+                else{
+                    NSUserDefaults.standardUserDefaults().setObject("https://cdn.rawgit.com/JadenGeller/Helium/master/helium_start.html", forKey: UserSetting.HomePageURL.userDefaultsKey)
+                }
+                
+                // Load
+                self.webViewController.loadAlmostURL(NSUserDefaults.standardUserDefaults().stringForKey(UserSetting.HomePageURL.userDefaultsKey)!)
+            }
+        })
+    }
+        
     func didBecomeActive() {
         panel.ignoresMouseEvents = false
     }

--- a/Helium/Helium/UserSettings.swift
+++ b/Helium/Helium/UserSettings.swift
@@ -11,11 +11,13 @@ import Foundation
 public enum UserSetting {
     case DisabledMagicURLs
     case DisabledFullScreenFloat
+    case HomePageURL
 
     var userDefaultsKey: String {
         switch self {
         case .DisabledMagicURLs: return "disabledMagicURLs"
         case .DisabledFullScreenFloat: return "disabledFullScreenFloat"
+        case .HomePageURL: return "homePageURL"
         }
     }
 }

--- a/Helium/Helium/WebViewController.swift
+++ b/Helium/Helium/WebViewController.swift
@@ -128,7 +128,13 @@ class WebViewController: NSViewController, WKNavigationDelegate {
         webView.reload()
     }
     func clear() {
-        loadURL(NSURL(string: "https://cdn.rawgit.com/JadenGeller/Helium/master/helium_start.html")!)
+        // Reload to home page (or default if no URL stored in UserDefaults)
+        if let homePage = NSUserDefaults.standardUserDefaults().stringForKey(UserSetting.HomePageURL.userDefaultsKey) {
+            loadAlmostURL(homePage)
+        }
+        else{
+            loadURL(NSURL(string: "https://cdn.rawgit.com/JadenGeller/Helium/master/helium_start.html")!)
+        }
     }
 
     var webView = WKWebView()


### PR DESCRIPTION
Added ability to set custom home page that is loaded whenever Helium starts.

Home page can be set within the Preferences menu, or with the hotkey `⌘,`.

Addresses #148.