### PR TITLE
Move Twitch to https

### DIFF
--- a/Helium/Helium/WebViewController.swift
+++ b/Helium/Helium/WebViewController.swift
@@ -147,7 +147,7 @@ class WebViewController: NSViewController, WKNavigationDelegate {
             modified = modified.replacePrefix("https://www.youtube.com/watch?", replacement: "https://www.youtube.com/watch_popup?")
             modified = modified.replacePrefix("https://vimeo.com/", replacement: "http://player.vimeo.com/video/")
             modified = modified.replacePrefix("http://v.youku.com/v_show/id_", replacement: "http://player.youku.com/embed/")
-            modified = modified.replacePrefix("http://www.twitch.tv/", replacement: "http://player.twitch.tv?&channel=")
+            modified = modified.replacePrefix("https://www.twitch.tv/", replacement: "https://player.twitch.tv?&channel=")
             
         if self.uneditedURL.containsString("https://youtu.be") {
                 if urlString.containsString("?t=") {


### PR DESCRIPTION
It seems like [Twitch is moving to https-only](https://blog.twitch.tv/building-a-better-twitch-updating-to-https-cf06c7a02c3a#.ls2ybvgei).
This PR changes the default URL from and to Twitch to `https`.

Let me know if I can change something.

Thanks!