### PR TITLE
Set URL TextView on focus in alert view

### DIFF
--- a/Helium/Helium/HeliumPanelController.swift
+++ b/Helium/Helium/HeliumPanelController.swift
@@ -242,6 +242,7 @@ class HeliumPanelController : NSWindowController {
         urlField.usesSingleLineMode = true
         
         alert.accessoryView = urlField
+        alert.accessoryView.becomeFirstResponder()
         alert.addButtonWithTitle("Load")
         alert.addButtonWithTitle("Cancel")
         alert.beginSheetModalForWindow(self.window!, completionHandler: { response in


### PR DESCRIPTION
Hi @JadenGeller,

I basically have no experience in development for Mac so I mostly stackoverflowed this solution.
The problem I am addressing is when you trying to set url using hotkeys `⌘+L` the URL TextView appears not focused, so you still need to use mouse to put a cursor in it.
That patch supposed to set the TextView focus on `Alert` view initialisation.